### PR TITLE
Add Avid Media Composer to Implementation Report

### DIFF
--- a/Implementation_Report_3e/index.html
+++ b/Implementation_Report_3e/index.html
@@ -538,6 +538,7 @@
                     <ul>
                         <li><a href="https://affinity.help/photo2/en-US.lproj/index.html?page=pages/Appendix/fileformat.html&title=Supported%20file%20formats">Includes 32-bit HDR support with an Alpha Channel (PNG specification - Third edition) for interchanging HDR broadcast imagery in a lossless format. CICP's Full-Range-Flag is supported to differentiate between Full/Narrow Range quantizations. Legacy PNG files exported from Photoshop with CICP data embedded in an ICC profile can be imported.</a></li>
                     </ul>
+		    <p>Implemented in <a href="https://www.avid.com/media-composer"><strong>Avid Media Composer</strong></a></p>
                     <figure>
                         <img src="./img/Affinity-23bit-HDR-PNG.png" alt="what's new in Affinity apps">
                         <figcaption>Affinity apps respect 'cICP' when importing and exporting HDR PNG</figcaption>


### PR DESCRIPTION
Chris Seeger confirmed that Avid Media Composer added CICP support as mentioned here:
https://lists.w3.org/Archives/Public/public-png/2024Aug/0002.html

This commit adds Avid Media Composer to the cICP section of the Implementation Report.