### PR TITLE
[ImpReport] add Servo results

### DIFF
--- a/Implementation_Report_3e/index.html
+++ b/Implementation_Report_3e/index.html
@@ -1003,12 +1003,14 @@
                                     <th>Edge 127</th>
                                     <th>Firefox 126</th>
                                     <th>Safari TP 196</th>
+                                    <th>Servo 0</th>
                                 </tr>
                                 <tr class="test">
                                     <td class="testname">trns-chunk.html</td>
                                     <td class="result passes-all"></td>
                                     <td class="result passes-all"></td>
                                     <td class="result passes-none"></td>
+                                    <td class="result passes-all"></td>
                                     <td class="result passes-all"></td>
                                 </tr>
                             </table>
@@ -1035,6 +1037,7 @@
                                     <th>Edge 127</th>
                                     <th>Firefox 126</th>
                                     <th>Safari TP 196</th>
+                                    <th>Servo 0</th>
                                 </tr>
                                 <tr class="test">
                                     <td class="testname">unknown-ancillary-error-recovery.html </td>
@@ -1042,9 +1045,11 @@
                                     <td class="result passes-all"></td>
                                     <td class="result passes-none"></td>
                                     <td class="result passes-none"></td>
+                                    <td class="result passes-all"></td>
                                 </tr>
                                 <tr class="test">
                                     <td class="testname">unknown-ancillary-error-recovery-2.html </td>
+                                    <td class="result passes-all"></td>
                                     <td class="result passes-all"></td>
                                     <td class="result passes-all"></td>
                                     <td class="result passes-all"></td>


### PR DESCRIPTION
[Servo](https://servo.org/), a web browser engine written in Rust, is an independent implementation so is important despite being less mature than the main browser engines. Servo results are not displayed by default on WPT.fyi but can be enabled.

Servo implements PNG (but not APNG and not `cICP`) however I noticed that it does correctly implement the Third Edition handling of invalid palette indexes and the handling of unknown invalid ancillary chunks:

- [ancillary chunks](https://wpt.fyi/results/png/errors?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=servo&aligned)
- [palette indexes](https://wpt.fyi/results/png/trns-chunk.html?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=servo&aligned)

This PR adds Servo results for those two categories to the implementation report.