### PR TITLE
Move editors to editor section

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,10 @@
         { name: "Chris Blume", url: "https://www.programmax.net", company: "W3C Invited Experts", w3cid: 127631 },
         { name: "Pierre-Anthony Lemieux", company: "MovieLabs", companyURL: "https://movielabs.com/", url: "mailto:pal@palemieux.com", w3cid: 57073 },
         { name: "Chris Lilley", url: "https://svgees.us", company: "W3C", companyURL: "https://www.w3.org", w3cid: 1438 },
+        { name: "Chris Needham", url: "https://chrisneedham.com/about" },
         { name: "Leonard Rosenthol", company: "Adobe Inc.", companyURL: "https://www.adobe.com", w3cid: 42485 },
         { name: "Chris Arley Seeger", company: "NBCUniversal, LLC a subsidiary of Comcast Corporation", companyURL: "https://www.xfinity.com", w3cid: 125844 }
+        { name: "Simon Thompson", company: "British Broadcasting Corporation", companyURL: "https://www.bbc.co.uk" },
       ],
       formerEditors: [
         { name: "Thomas Boutell" },
@@ -56,7 +58,6 @@
         { name: "Chris Lilley", url: "https://svgees.us", company: "W3C", companyURL: "https://www.w3.org" },
         { name: "Dave Martindale" },
         { name: "Owen Mortensen" },
-        { name: "Chris Needham", url: "https://chrisneedham.com/about" },
         { name: "Stuart Parmenter"},
         { name: "Keith S. Pickens" },
         { name: "Robert P. Poole" },
@@ -67,7 +68,6 @@
         { name: "Paul Schmidt" },
         { name: "Andrew Smith" },
         { name: "Michael Stokes" },
-        { name: "Simon Thompson", company: "British Broadcasting Corporation", companyURL: "https://www.bbc.co.uk" },
         { name: "Vladimir Vukicevic" },
         { name: "Tim Wegner" },
         { name: "Jeremy Wohl" }


### PR DESCRIPTION
Two new editors were added to the authors section. I believe the authors section is intended for the original authors of 1.0. When someone updates the spec, I believe they should be listed as an editor.

This commit moves two people from the authors section to the editors section to reflect this.