### PR TITLE
Correct JSON commas

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,15 +31,15 @@
         { name: "Chris Lilley", url: "https://svgees.us", company: "W3C", companyURL: "https://www.w3.org", w3cid: 1438 },
         { name: "Chris Needham", url: "https://chrisneedham.com/about" },
         { name: "Leonard Rosenthol", company: "Adobe Inc.", companyURL: "https://www.adobe.com", w3cid: 42485 },
-        { name: "Chris Arley Seeger", company: "NBCUniversal, LLC a subsidiary of Comcast Corporation", companyURL: "https://www.xfinity.com", w3cid: 125844 }
-        { name: "Simon Thompson", company: "British Broadcasting Corporation", companyURL: "https://www.bbc.co.uk" },
+        { name: "Chris Arley Seeger", company: "NBCUniversal, LLC a subsidiary of Comcast Corporation", companyURL: "https://www.xfinity.com", w3cid: 125844 },
+        { name: "Simon Thompson", company: "British Broadcasting Corporation", companyURL: "https://www.bbc.co.uk" }
       ],
       formerEditors: [
         { name: "Thomas Boutell" },
         { name: "Adam M. Costello" },
         { name: "David Duce" },
         { name: "Tom Lane" },
-        { name: "Glenn Randers-Pehrson" },
+        { name: "Glenn Randers-Pehrson" }
       ],
       authors: [
         { name: "Mark Adler", url: "https://en.wikipedia.org/wiki/Mark_Adler" },


### PR DESCRIPTION
In commit 1d54517, some JSON objects were moved around. The missing trailing comma typical to JSON was not added back for the non-trailing case. This caused a parsing error.

This commit corrects the commas from that previous commit.

It also removes a trailing comma that was apparently previously allowed. This matches the style of the rest of the JSON. Although, perhaps we should opt into trailing commas to make life easier.