### PR TITLE
Add w3cids to new editors

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,10 +29,10 @@
         { name: "Chris Blume", url: "https://www.programmax.net", company: "W3C Invited Experts", w3cid: 127631 },
         { name: "Pierre-Anthony Lemieux", company: "MovieLabs", companyURL: "https://movielabs.com/", url: "mailto:pal@palemieux.com", w3cid: 57073 },
         { name: "Chris Lilley", url: "https://svgees.us", company: "W3C", companyURL: "https://www.w3.org", w3cid: 1438 },
-        { name: "Chris Needham", url: "https://chrisneedham.com/about" },
+        { name: "Chris Needham", url: "https://chrisneedham.com/about", w3cid: 67414 },
         { name: "Leonard Rosenthol", company: "Adobe Inc.", companyURL: "https://www.adobe.com", w3cid: 42485 },
         { name: "Chris Arley Seeger", company: "NBCUniversal, LLC a subsidiary of Comcast Corporation", companyURL: "https://www.xfinity.com", w3cid: 125844 },
-        { name: "Simon Thompson", company: "British Broadcasting Corporation", companyURL: "https://www.bbc.co.uk" }
+        { name: "Simon Thompson", company: "British Broadcasting Corporation", companyURL: "https://www.bbc.co.uk", w3cid: 100939 }
       ],
       formerEditors: [
         { name: "Thomas Boutell" },


### PR DESCRIPTION
With Chris Needham and Simon Thompson added to the editors list, ReSpec was warning that editors were missing w3cids.

This commit adds their w3cids.