### PR TITLE
fixed reference to cd/m2 in wrong column in MDCV chunk

### DIFF
--- a/index.html
+++ b/index.html
@@ -3912,7 +3912,7 @@ with these exceptions:
             <tr>
               <td>Mastering display minimum luminance (measured in cd/m<sup>2</sup>)</td>
               <td>4 bytes</td>
-              <td>0.0001 cd/m<sup>2</sup></td>
+              <td>0.0001</td>
             </tr>
           </table>
 


### PR DESCRIPTION
This was to fix the reference to cd/m2 in the divisor column when it should be in the description column.  A previous branch attempted to fix this but for some reason both moves (Max and min) didn't make it into the final pull request.  This should address the other column's move.