### PR TITLE
Rename cLLi to cLLI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2014,7 +2014,7 @@ with these exceptions:
 
         <tr>
           <td>
-            <a class="chunk" href="#cLLi-chunk">cLLi</a>
+            <a class="chunk" href="#cLLI-chunk">cLLI</a>
           </td>
           <td>No</td>
           <td>
@@ -3848,7 +3848,7 @@ with these exceptions:
           on a comparison of its inherent capabilities versus the original mastering display's capabilites.</p>
 
           <p>mDCv is typically used with the <a>PQ</a> [[ITU-R-BT.2100]] transfer function
-          and additional <a href="#cLLi-chunk">cLLI</a> metadata and is commonly then called 
+          and additional <a href="#cLLI-chunk">cLLI</a> metadata and is commonly then called 
           [[?HDR10]] (PQ with ST 2086 static metadata, MaxFALL and MaxCLL).
           The mDCv chunk may also be included with <a>HLG</a> [[ITU-R-BT.2100]] and 
           <a>SDR</a> image formats (for example [[ITU-R-BT.709]]). </p>
@@ -4124,16 +4124,16 @@ with these exceptions:
           </aside>
         </section>
 
-        <section id="cLLi-chunk">
-          <h2><span class="chunk">cLLi</span> Content Light Level Information</h2>
+        <section id="cLLI-chunk">
+          <h2><span class="chunk">cLLI</span> Content Light Level Information</h2>
           <p>The four-byte chunk type field contains the hexadecimal values</p>
 
           <pre>
-<!-- 99 76 76 105 -->63 4C 4C 69
+<!-- 99 76 76 73 -->63 4C 4C 49
 </pre>
-          <p>If present, the <span class="chunk">cLLi</span> chunk identifies two characteristics of <a>HDR</a> content:</p>
+          <p>If present, the <span class="chunk">cLLI</span> chunk identifies two characteristics of <a>HDR</a> content:</p>
 
-          <p>The <span class="chunk">cLLi</span> chunk adds static metadata which provides an opportunity
+          <p>The <span class="chunk">cLLI</span> chunk adds static metadata which provides an opportunity
           to optimize tone mapping of the associated content to a specific target display. This is 
           accomplished by tailoring the tone mapping of the content itself to the specific peak brightness 
           capabilities of the target display to prevent clipping. The method of tone-mapping optimization 
@@ -4152,7 +4152,7 @@ with these exceptions:
 	  <p>The MaxCLL and MaxFALL values are encoded as <a>PNG four-byte unsigned integers</a>.</p>
 
           <p class="note">[[CTA-861.3-A]] describes the method of calculation for generating the
-            <span class="chunk">cLLi</span> values,
+            <span class="chunk">cLLI</span> values,
             but does not specify any filtering.
             [[HDR-Static-Meta]] describes an improved method which rejects extreme values from
             statistical outliers, noise or ringing from resampling filters,
@@ -4160,10 +4160,10 @@ with these exceptions:
           </p>
 
           <p class="note">[[SMPTE-ST-2067-21]] Section 7.5 adds additional
-            information in Section 7.5 in the case where the <span class="chunk">cLLi</span> values are unknown and have not been calculated.</p>
+            information in Section 7.5 in the case where the <span class="chunk">cLLI</span> values are unknown and have not been calculated.</p>
 
           <p class="note"><a href="https://github.com/w3c/png/issues/319">Issue #319</a> discusses tone-mapping behavior when
-          the <span class="chunk">cLLi</span> chunk is present.</p>
+          the <span class="chunk">cLLI</span> chunk is present.</p>
 
           <p>Each <a>frame</a> is analyzed.</p>
 
@@ -4171,10 +4171,10 @@ with these exceptions:
 
           <p class="note">An example where this will not be calculable is when creating a live animated PNG stream, when not all frames will be available to compute the values until the stream ends.  The encoder may wish to use the value zero initially and replace this with the calculated value when the stream ends.</p>
 
-           <p>The following specifies the syntax of the <span class="chunk">cLLi</span> chunk:</p>
+           <p>The following specifies the syntax of the <span class="chunk">cLLI</span> chunk:</p>
 
-           <table id="cLLi-chunk-syntax" class="numbered simple">
-             <caption>cLLi chunk components</caption>
+           <table id="cLLI-chunk-syntax" class="numbered simple">
+             <caption>cLLI chunk components</caption>
 
              <tr>
                <th>Name</th>
@@ -4196,9 +4196,9 @@ with these exceptions:
            </table>
 
            <aside class="example">
-             Example <span class="chunk">cLLi</span> chunk Maximum Content Light Level:
+             Example <span class="chunk">cLLI</span> chunk Maximum Content Light Level:
 
-             <table id="cLLi-chunk-max-content-light-level-example" class="numbered simple">
+             <table id="cLLI-chunk-max-content-light-level-example" class="numbered simple">
                <tr>
                  <th>Actual value</th>
                  <th>Stored Decimal values</th>
@@ -4214,9 +4214,9 @@ with these exceptions:
            </aside>
 
            <aside class="example">
-             Example <span class="chunk">cLLi</span> chunk Maximum Frame-Average Light Level:
+             Example <span class="chunk">cLLI</span> chunk Maximum Frame-Average Light Level:
 
-             <table id="cLLi-chunk-max-frame-avg-luminance-example" class="numbered simple">
+             <table id="cLLI-chunk-max-frame-avg-luminance-example" class="numbered simple">
                <tr>
                  <th>Actual value</th>
                  <th>Stored Decimal values</th>
@@ -7609,7 +7609,8 @@ will need to be replaced by copies of lines 17-23, but processing background ins
     <h3 id="changes-20230921">Changes since the <a href="https://www.w3.org/TR/2023/CR-png-3-20230921/">Candidate Recommendation Snapshot of 21 September 2023 (Third Edition)</a></h3>
 
     <ul>
-      <!-- to 10 Jun 2024 -->
+      <!-- to 30 Oct 2024 -->
+      <li>Renamed <span class="chunk">cLLi</span> to <span class="chunk">cLLI</span></li>
       <li>Clarified that bit depth and color type fields can take private values</li>
       <li>Listed both decimal and hexadecimal values in MaxCLL and MaxFALL examples</li>
       <li>Corrected terminology in mDCv section</li>
@@ -7632,7 +7633,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
       <li>Updated link to latest version of ITU-R BT.2390</li>
       <li>Noted that currently there is no published standard to adapt an SDR image from default viewing conditions (display luminance and ambient illumination) to those given in <span class="chunk">mDCV</span></li>
       <li>Noted that the adaptation of BT.2100 HLG images to differing viewing conditions, given in BT.2390, may also be used with SDR images.</li>
-      <li>Noted that tone mapping, to adjust the luminance levels given in <span class="chunk">cLLi</span> to those of a target display to prevent clipping, is particularly important for formats such as BT.2100 PQ which use absolute luminance.</li>
+      <li>Noted that tone mapping, to adjust the luminance levels given in <span class="chunk">cLLI</span> to those of a target display to prevent clipping, is particularly important for formats such as BT.2100 PQ which use absolute luminance.</li>
       <li>Noted that use of full-range BT.709 values, while common, is not part of the BT.709 standard</li>
       <li>Added mention of protected code values for Serial Digital Interface (baseband video) in description of narrow-range and full-range video</li>
       <li>Added reference to ITU-R-BT.2390</li>
@@ -7658,22 +7659,22 @@ will need to be replaced by copies of lines 17-23, but processing background ins
 
     <ul>
       <!-- to 21 Sept 2023 -->
-      <li>Clarified descriptions of <span class="chunk">mDCv</span> and <span class="chunk">cLLi</span></li>
+      <li>Clarified descriptions of <span class="chunk">mDCv</span> and <span class="chunk">cLLI</span></li>
       <li>Added note to Security Considerations about potentially malicious data after <span class="chunk">IEND</span>.</li>
-      <li>Clarified that <a href="#cLLi-chunk" class="chunk">cLLi</a> is for HDR content</li>
+      <li>Clarified that <a href="#cLLI-chunk" class="chunk">cLLI</a> is for HDR content</li>
       <li>Added an informative reference to Smith &amp; Zink "On the Calculation and Usage of HDR Static Content Metadata"</li>
       <li>Added an informative reference to CTA-861.3-A for static HDR metadata</li>
       <li>Fixed broken reference to ITU-R BT.2100 </li>
       <li>Updated reference to SMPTE-ST-2067-21</li>
       <!-- to 26 Aug 2023 -->
       <li>Added guidance on calculating MaxCLL and MaxFALL values</li>
-      <li>Added example (live streaming) where <a href="#cLLi-chunk" class="chunk">cLLi</a> could not be pre-calculated</li>
+      <li>Added example (live streaming) where <a href="#cLLI-chunk" class="chunk">cLLI</a> could not be pre-calculated</li>
       <li>Added definitions for stop, SDR, HDR, HLG and PQ</li>
       <li>Clarified definition of narrow-range</li>
       <li>Updated ITU-T H Suppl. 19 reference to latest version</li>
       <li>Added Simon Thompson as an author</li>
       <li>Mandated current browser handling of out-of-range palette indices</li>
-      <li>Updated "Additional Information" table to add <a href="#mDCv-chunk" class="chunk">mDCv</a> and <a href="#cLLi-chunk" class="chunk">cLLi</a>.</li>
+      <li>Updated "Additional Information" table to add <a href="#mDCv-chunk" class="chunk">mDCv</a> and <a href="#cLLI-chunk" class="chunk">cLLI</a>.</li>
     </ul>
 
     <h3 id="changes-20221025">Changes since the <a href="https://www.w3.org/TR/2022/WD-png-3-20221025/">
@@ -7702,7 +7703,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
         which conflicted with the <a href="#5ChunkOrdering">chunk ordering</a> section.</li>
       <li>Simplified <a href="#1Scope">Scope</a> section to remove redundant detail described elsewhere.</li>
       <li>Redrew chunk-ordering lattice diagrams to be clearer and more consistent.</li>
-      <li>Added a new chunk, <a href="#cLLi-chunk" class="chunk">cLLi</a>,
+      <li>Added a new chunk, <a href="#cLLI-chunk" class="chunk">cLLI</a>,
       to describe the Maximum Single-Pixel and Frame-Average Luminance Levels
       for both static and animated <a>HDR</a> [[ITU-R-BT.2100]] PNG images.
 
@@ -7761,7 +7762,7 @@ will need to be replaced by copies of lines 17-23, but processing background ins
 
       <li>
         <p>To help with tonemapping HDR content, added the <a class="chunk" href="#mDCv-chunk">mDCv</a> chunk, which contains metadata about the display used in
-          mastering, and <a href="#cLLi-chunk" class="chunk">cLLi</a>, which contains metadata about peak and average light levels. This enabled more accurate color matching on heterogeneous platforms</p>
+          mastering, and <a href="#cLLI-chunk" class="chunk">cLLI</a>, which contains metadata about peak and average light levels. This enabled more accurate color matching on heterogeneous platforms</p>
       </li>
 
       <li>


### PR DESCRIPTION
The cLLI chunk depends on image data. As a result, it is not safe to copy if that pixel data changes.

This commit renames the cLLi chunk to cLLI to reflect the unsafe-to-copy behavior.