### PR TITLE
Consistently require only that acTL is before IDAT, not PLTE #467

### DIFF
--- a/index.html
+++ b/index.html
@@ -1957,7 +1957,7 @@ with these exceptions:
           </td>
           <td>No</td>
           <td>
-            Before <a class="chunk" href="#11PLTE">PLTE</a> and <a class="chunk" href="#11IDAT">IDAT</a>
+            Before <a class="chunk" href="#11IDAT">IDAT</a>
           </td>
         </tr>
 


### PR DESCRIPTION
The `acTL` chunk description, and the lattice diagrams, show that `acTL` is only required to be before `IDAT`, not before `PLTE` as well. This PR makes the chunk ordering table consistent with the chunk description and lattice diagrams.