### PR TITLE
Update SVG figures for mDCV, cLLI

### DIFF
--- a/figures/lattice-diagram-apng-static-first-with-plte.svg
+++ b/figures/lattice-diagram-apng-static-first-with-plte.svg
@@ -118,12 +118,12 @@
 </g>
 <g transform="translate(695,0)">
 <rect width="55" height="40" />
-<text x="5" y="25">mDCv</text>
+<text x="5" y="25">mDCV</text>
 <text x="45" y="12" style="font-size:8pt">?</text>
 </g>
 <g transform="translate(755,0)">
 <rect width="55" height="40" />
-<text x="5" y="25">cLLi</text>
+<text x="5" y="25">cLLI</text>
 <text x="45" y="12" style="font-size:8pt">?</text>
 </g>
 </g>

--- a/figures/lattice-diagram-apng-static-first-without-plte.svg
+++ b/figures/lattice-diagram-apng-static-first-without-plte.svg
@@ -101,13 +101,13 @@
 
 <g transform="translate(680,0)">
 <rect width="50" height="40" />
-<text x="5" y="25">mDVc</text>
+<text x="5" y="25">mDCV</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
 
 <g transform="translate(740,0)">
 <rect width="50" height="40" />
-<text x="5" y="25">cLLi</text>
+<text x="5" y="25">cLLI</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
 

--- a/figures/lattice-diagram-apng-static-notfirst-with-plte.svg
+++ b/figures/lattice-diagram-apng-static-notfirst-with-plte.svg
@@ -114,12 +114,12 @@
 </g>
 <g transform="translate(695,0)">
 <rect width="55" height="40" />
-<text x="5" y="25">mDCv</text>
+<text x="5" y="25">mDCV</text>
 <text x="45" y="12" style="font-size:8pt">?</text>
 </g>
 <g transform="translate(755,0)">
 <rect width="55" height="40" />
-<text x="5" y="25">cLLi</text>
+<text x="5" y="25">cLLI</text>
 <text x="45" y="12" style="font-size:8pt">?</text>
 </g>
 </g>

--- a/figures/lattice-diagram-apng-static-notfirst-without-plte.svg
+++ b/figures/lattice-diagram-apng-static-notfirst-without-plte.svg
@@ -101,13 +101,13 @@
 
 <g transform="translate(680,0)">
 <rect width="50" height="40" />
-<text x="5" y="25">mDVc</text>
+<text x="5" y="25">mDCV</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
 
 <g transform="translate(740,0)">
 <rect width="50" height="40" />
-<text x="5" y="25">cLLi</text>
+<text x="5" y="25">cLLI</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
 

--- a/figures/lattice-diagram-with-plte.svg
+++ b/figures/lattice-diagram-with-plte.svg
@@ -114,12 +114,12 @@
 </g>
 <g transform="translate(695,0)">
 <rect width="55" height="40" />
-<text x="5" y="25">mDCv</text>
+<text x="5" y="25">mDCV</text>
 <text x="45" y="12" style="font-size:8pt">?</text>
 </g>
 <g transform="translate(755,0)">
 <rect width="55" height="40" />
-<text x="5" y="25">cLLi</text>
+<text x="5" y="25">cLLI</text>
 <text x="45" y="12" style="font-size:8pt">?</text>
 </g>
 </g>

--- a/figures/lattice-diagram-without-plte.svg
+++ b/figures/lattice-diagram-without-plte.svg
@@ -101,13 +101,13 @@
 
 <g transform="translate(680,0)">
 <rect width="50" height="40" />
-<text x="5" y="25">mDVc</text>
+<text x="5" y="25">mDCV</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
 
 <g transform="translate(740,0)">
 <rect width="50" height="40" />
-<text x="5" y="25">cLLi</text>
+<text x="5" y="25">cLLI</text>
 <text x="40" y="12" style="font-size:8pt">?</text>
 </g>
 


### PR DESCRIPTION
The earlier find and replace had missed the figures because they are separate files.

Also corrected a typo (mDVc) to mDCV