### PR TITLE
Rename cicp_inserter to png_cicp_editor

### DIFF
--- a/Implementation_Report_3e/index.html
+++ b/Implementation_Report_3e/index.html
@@ -616,7 +616,7 @@
                     <p>Implemented in <a href="https://github.com/pnggroup/pngcheck"><strong>pngcheck</strong></a>,
                     a command-line PNG validator.</p>
 
-                    <p>Implemented in <a href="https://github.com/ProgramMax/cicp_inserter">cicp_inserter </a>,
+                    <p>Implemented in <a href="https://github.com/ProgramMax/png_cicp_editor">png_cicp_editor </a>,
                      a command-line tool to add 'cICP' chunks to existing PNG files.</p>
     
                     <section class="tests" id="cicp-chunk">

--- a/tools.md
+++ b/tools.md
@@ -31,9 +31,9 @@ Depends on libpng. Originally a fork of pngcrush by Cosmin Truta, now has a diff
 
 PNG compression optimizer, written in Rust. [Recognizes `cICP` chunks and does not discard them](https://github.com/shssoichiro/oxipng/issues/538#issuecomment-1644266228).
 
-### cicp_inserter
+### png_cicp_editor
 
-[Homepage](https://github.com/ProgramMax/cicp_inserter/blob/tip-of-tree/Docs/README.md) and [maintained on GitHub](https://github.com/ProgramMax/cicp_inserter)
+[Homepage](https://github.com/ProgramMax/png_cicp_editor/blob/tip-of-tree/Docs/README.md) and [maintained on GitHub](https://github.com/ProgramMax/png_cicp_editor)
 
 Command-line tool in C++ to insert (and optionally, overwrite) a `cICP` chunk in an existing PNG file. Maintained by Chris Blume.
 


### PR DESCRIPTION
The cicp_inserter project has been renamed to png_cicp_editor to reflect the fact that it can now do more than insert.

This commit updates references to the name.