### PR TITLE
Firefox trns pass

### DIFF
--- a/Implementation_Report_3e/index.html
+++ b/Implementation_Report_3e/index.html
@@ -150,10 +150,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/png/apng?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=actl">Live Results</a></th>
-                            <th>Chrome 135</th>
-                            <th>Edge 134</th>
-                            <th>Firefox 137</th>
-                            <th>Safari TP 213</th>
+                            <th>Chrome 137</th>
+                            <th>Edge 137</th>
+                            <th>Firefox 139</th>
+                            <th>Safari TP 217</th>
                             <th>Ladybird 1</th>
                         </tr>
                         <tr class="test">
@@ -177,10 +177,10 @@
                     <table>
                         <tr class="header">
                             <th>Manual tests</th>
-                            <th>Chrome 135</th>
-                            <th>Edge 134</th>
-                            <th>Firefox 137</th>
-                            <th>Safari TP 213</th>
+                            <th>Chrome 137</th>
+                            <th>Edge 137</th>
+                            <th>Firefox 139</th>
+                            <th>Safari TP 217</th>
                         </tr>
                         <tr class="test">
                             <td class="testname">acTL-plays-one-manual.html </td>
@@ -212,10 +212,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/png/apng?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=fctl">Live Results</a></th>
-                            <th>Chrome 135</th>
-                            <th>Edge 134</th>
-                            <th>Firefox 137</th>
-                            <th>Safari TP 213</th>
+                            <th>Chrome 137</th>
+                            <th>Edge 137</th>
+                            <th>Firefox 139</th>
+                            <th>Safari TP 217</th>
                             <th>Ladybird 1</th>
                         </tr>
                         <tr class="test">
@@ -351,10 +351,10 @@
                     <table>
                         <tr class="header">
                             <th>Manual tests</th>
-                            <th>Chrome 135</th>
-                            <th>Edge 134</th>
-                            <th>Firefox 137</th>
-                            <th>Safari TP 213</th>
+                            <th>Chrome 137</th>
+                            <th>Edge 137</th>
+                            <th>Firefox 139</th>
+                            <th>Safari TP 217</th>
                         </tr>
                         <tr class="test">
                             <td class="testname">fcTL-delay-16bit-manual.html </td>
@@ -399,10 +399,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/png/apng?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=fdat">Live Results</a></th>
-                            <th>Chrome 135</th>
-                            <th>Edge 134</th>
-                            <th>Firefox 137</th>
-                            <th>Safari TP 213</th>
+                            <th>Chrome 137</th>
+                            <th>Edge 137</th>
+                            <th>Firefox 139</th>
+                            <th>Safari TP 217</th>
                             <th>Ladybird 1</th>
                         </tr>
                         <tr class="test">
@@ -485,10 +485,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/png/apng?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=first">Live Results</a></th>
-                            <th>Chrome 135</th>
-                            <th>Edge 134</th>
-                            <th>Firefox 137</th>
-                            <th>Safari TP 213</th>
+                            <th>Chrome 137</th>
+                            <th>Edge 137</th>
+                            <th>Firefox 139</th>
+                            <th>Safari TP 217</th>
                             <th>Ladybird 1</th>
                         </tr>
                         <tr class="test">
@@ -512,10 +512,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/apng?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=timeout">Live Results</a></th>
-                            <th>Chrome 135</th>
-                            <th>Edge 134</th>
-                            <th>Firefox 137</th>
-                            <th>Safari TP 213</th>
+                            <th>Chrome 137</th>
+                            <th>Edge 137</th>
+                            <th>Firefox 139</th>
+                            <th>Safari TP 217</th>
                             <th>Ladybird 1</th>
                         </tr>
                         <tr class="test">
@@ -531,10 +531,10 @@
                     <table>
                         <tr class="header">
                             <th><a href="https://wpt.fyi/results/apng?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=source">Live Results</a></th>
-                            <th>Chrome 135</th>
-                            <th>Edge 134</th>
-                            <th>Firefox 137</th>
-                            <th>Safari TP 213</th>
+                            <th>Chrome 137</th>
+                            <th>Edge 137</th>
+                            <th>Firefox 139</th>
+                            <th>Safari TP 217</th>
                             <th>Ladybird 1</th>
                         </tr>
                         <tr class="test">
@@ -624,10 +624,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/png?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=cicp">Live Results</a></th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                                 <th>Ladybird 1</th>
                             </tr>
                             <tr class="test">
@@ -651,10 +651,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/png/apng?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=cicp">Live Results</a></th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                                 <th>Ladybird 1</th>
                             </tr>
                             <tr class="test">
@@ -684,10 +684,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/png?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=wins">Live Results</a></th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                                 <th>Ladybird 1</th>
                             </tr>
                             <tr class="test">
@@ -703,10 +703,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/css/css-color?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=tagged">Live Results</a></th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                                 <th>Ladybird 1</th>
                             </tr>
                             <tr class="test">
@@ -841,10 +841,10 @@
                             <tr class="header">
                                 <th><a href="https://svgees.us/PNG/iCCP/tests.html">Manual tests</a> 
                                 (<a href="https://svgees.us/PNG/iCCP/results.html">Archived results</a>)  </th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">'sRGB' chunk, relative colorimetric intent</td>
@@ -866,10 +866,10 @@
                             <tr class="header">
                                 <th><a href="https://svgees.us/PNG/iCCP/tests.html">Manual tests</a> 
                                 (<a href="https://svgees.us/PNG/iCCP/results.html">Archived results</a>)  </th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">sRGB with red and green colorants swapped</td>
@@ -898,10 +898,10 @@
                             <tr class="header">
                                 <th><a href="https://svgees.us/PNG/iCCP/tests.html">Manual tests</a> 
                                 (<a href="https://svgees.us/PNG/iCCP/results.html">Archived results</a>)  </th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">CIE RGB, L* TRC</td>
@@ -964,10 +964,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/png?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=exif">Live Results</a></th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                                 <th>Ladybird 1</th>
                             </tr>
                             <tr class="test">
@@ -983,10 +983,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/css/css-images/image-orientation/image-orientation-from-image.html?label=experimental&label=master&aligned">Live Results</a></th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">image-orientation-from-image.html </td>
@@ -999,10 +999,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/css/css-images/image-orientation/image-orientation-from-image-embedded-content.html?label=experimental&label=master&aligned">Live Results</a></th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                             </tr>
                             <tr class="test">
                                 <td class="testname">image-orientation-from-image-embedded-content.html </td>
@@ -1016,10 +1016,10 @@
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/css/css-images/image-orientation?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=exif">Live Results</a></th>
-                                <th>Chrome 135</th>
-                                <th>Edge 134</th>
-                                <th>Firefox 137</th>
-                                <th>Safari TP 213</th>
+                                <th>Chrome 137</th>
+                                <th>Edge 137</th>
+                                <th>Firefox 139</th>
+                                <th>Safari TP 217</th>
                                 <th>Ladybird 1</th>
                             </tr>
                             <tr class="test">
@@ -1077,10 +1077,10 @@
                             <table>
                                 <tr class="header">
                                     <th><a href="https://wpt.fyi/results/png?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&product=servo&q=trns-chunk">Live Results</a></th>
-                                    <th>Chrome 135</th>
-                                    <th>Edge 134</th>
-                                    <th>Firefox 137</th>
-                                    <th>Safari TP 213</th>
+                                    <th>Chrome 137</th>
+                                    <th>Edge 137</th>
+                                    <th>Firefox 139</th>
+                                    <th>Safari TP 217</th>
                                     <th>Servo 0</th>
                                     <th>Ladybird 1</th>
                                 </tr>
@@ -1113,10 +1113,10 @@
                             <table>
                                 <tr class="header">
                                     <th><a href="https://wpt.fyi/results/png/errors?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&product=servo">Live Results</a></th>
-                                    <th>Chrome 135</th>
-                                    <th>Edge 134</th>
-                                    <th>Firefox 137</th>
-                                    <th>Safari TP 213</th>
+                                    <th>Chrome 137</th>
+                                    <th>Edge 137</th>
+                                    <th>Firefox 139</th>
+                                    <th>Safari TP 217</th>
                                     <th>Servo 0</th>
                                     <th>Ladybird 1</th>
                                 </tr>

--- a/Implementation_Report_3e/index.html
+++ b/Implementation_Report_3e/index.html
@@ -1088,7 +1088,7 @@
                                     <td class="testname">trns-chunk.html</td>
                                     <td class="result passes-all"></td>
                                     <td class="result passes-all"></td>
-                                    <td class="result passes-none"></td>
+                                    <td class="result passes-all"></td>
                                     <td class="result passes-all"></td>
                                     <td class="result passes-all"></td>
                                     <td class="result passes-all"></td>


### PR DESCRIPTION
Firefox was the only browser to fail on the Third Edition `trns` test; as of today Firefox 139 nightly passes.

In this PR I also updated all browser versions to the ones currently used on WPT.