### PR TITLE
[ImpRpt] More passes for EXIF in PNG CSS tests

### DIFF
--- a/Implementation_Report_3e/index.html
+++ b/Implementation_Report_3e/index.html
@@ -1143,6 +1143,7 @@
                             </tr>
                         </table>
                         <h3>Exif in CSS tests (PNG)</h3>
+                        
                         <table>
                             <tr class="header">
                                 <th><a href="https://wpt.fyi/results/css/css-images/image-orientation?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&q=exif">Live Results</a></th>
@@ -1153,7 +1154,7 @@
                                 <th>Ladybird 1</th>
                             </tr>
                             <tr class="test">
-                                <td class="testname">image-orientation-exif-png.html </td>
+                                <td class="testname">image-orientation-exif-png.html [<a href="#wooly">1</a>]</td>
                                 <td class="result passes-none"></td>
                                 <td class="result passes-none"></td>
                                 <td class="result passes-none"></td>
@@ -1164,17 +1165,17 @@
                                 <td class="testname">image-orientation-exif-png-2.html </td>
                                 <td class="result passes-all"></td>
                                 <td class="result passes-all"></td>
-                                <td class="result passes-none"></td>
+                                <td class="result passes-all"></td>
                                 <td class="result passes-all"></td>
                                 <td class="result passes-all"></td>
                             </tr>
                             <tr class="test">
-                                <td class="testname">image-orientation-exif-png-3.html [<a href="#wooly">1</a>]</td>
-                                <td class="result passes-unclear"></td>
-                                <td class="result passes-unclear"></td>
-                                <td class="result passes-unclear"></td>
-                                <td class="result passes-unclear"></td>
-                                <td class="result passes-unclear"></td>
+                                <td class="testname">image-orientation-exif-png-3.html</td>
+                                <td class="result passes-all"></td>
+                                <td class="result passes-all"></td>
+                                <td class="result passes-all"></td>
+                                <td class="result passes-all"></td>
+                                <td class="result passes-all"></td>
                             </tr>
                         </table>
 


### PR DESCRIPTION
Due to progress in

- https://bugzilla.mozilla.org/show_bug.cgi?id=1682759
- https://bugzilla.mozilla.org/show_bug.cgi?id=1969853

Firefox now respects Exif orientation in PNG (if before `IDAT`)

A CSS bug in `css/css-images/image-orientation/image-orientation-exif-png-3.html`, which was causing automatic comparison to fail (for all browsers) due to slight misalignment, was fixed